### PR TITLE
Revise Global type document

### DIFF
--- a/docs/types.md
+++ b/docs/types.md
@@ -44,11 +44,11 @@ zsh: command not found: s
 
 ## Global
 
-Regular abbreviations expand everywhere.
+Global abbreviations expand everywhere.
 
 To scope a zsh-abbr command to the user, pass the `--global` flag or its shorthand `-g`.
 
-In the following examples, global abbreviations expand at the start of the line but not in other positions:
+In the following examples, global abbreviations can expand at any positions:
 
 
 ```shell{5}:no-line-numbers

--- a/docs/types.md
+++ b/docs/types.md
@@ -48,7 +48,7 @@ Global abbreviations expand everywhere.
 
 To scope a zsh-abbr command to the user, pass the `--global` flag or its shorthand `-g`.
 
-In the following examples, global abbreviations can expand at any positions:
+In the following examples, global abbreviations expand at the start of the line and also in other positions:
 
 
 ```shell{5}:no-line-numbers


### PR DESCRIPTION
It seems that the documentation on Global type is copied from Regular type docs without changes unexpectedly.

This PR fixes the Global type docs to match the actual contents.